### PR TITLE
Update deprecated dependencies to current versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jrei/systemd-ubuntu:20.04
+FROM jrei/systemd-ubuntu:22.04
 
 RUN mkdir -p /opt/veriscope
 

--- a/infra/configure/playbooks/install-bloom-filter.yaml
+++ b/infra/configure/playbooks/install-bloom-filter.yaml
@@ -8,7 +8,7 @@
     redisbloom_tarball: 'https://github.com/ShyftNetwork/RedisBloom/archive/refs/tags/v2.4.5.zip'
     redisbloom_dest: '/opt/RedisBloom'
     nginx_cfg: '/etc/nginx/sites-available/default'
-    php_version: '8.0'
+    php_version: '8.3'
 
   tasks:
     - name: Check if Redis server is installed - Install Redis Bloom Filter

--- a/infra/configure/playbooks/install-prerequisites.yaml
+++ b/infra/configure/playbooks/install-prerequisites.yaml
@@ -37,18 +37,18 @@
           - moreutils
           - net-tools
           - postgresql-client
-          - php8.0-fpm
-          - php8.0-dom
-          - php8.0-zip
-          - php8.0-mbstring
-          - php8.0-curl
-          - php8.0-dom
-          - php8.0-gd
-          - php8.0-imagick
-          - php8.0-pgsql
-          - php8.0-gmp
-          - php8.0-redis
-          - php8.0-mbstring
+          - php8.3-fpm
+          - php8.3-dom
+          - php8.3-zip
+          - php8.3-mbstring
+          - php8.3-curl
+          - php8.3-dom
+          - php8.3-gd
+          - php8.3-imagick
+          - php8.3-pgsql
+          - php8.3-gmp
+          - php8.3-redis
+          - php8.3-mbstring
           - nodejs
           - build-essential
           - nginx

--- a/infra/lambdas/modify-db-cluster-sg/modify-sg-on-demand/Dockerfile
+++ b/infra/lambdas/modify-db-cluster-sg/modify-sg-on-demand/Dockerfile
@@ -1,8 +1,8 @@
-FROM public.ecr.aws/lambda/python:3.8
+FROM public.ecr.aws/lambda/python:3.11
 
 COPY requirements.txt ./
 
-RUN python3.8 -m pip install -r requirements.txt -t .
+RUN python3.11 -m pip install -r requirements.txt -t .
 
 COPY app.py ./
 

--- a/veriscope_ta_dashboard/composer.json
+++ b/veriscope_ta_dashboard/composer.json
@@ -38,7 +38,7 @@
       }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.3",
         "cboden/ratchet": "v0.6.1",
         "asantibanez/laravel-eloquent-state-machines": "dev-master",
         "bayareawebpro/laravel-simple-csv": "v2.2.0",

--- a/veriscope_ta_dashboard/docker/8.0/Dockerfile
+++ b/veriscope_ta_dashboard/docker/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Yoel Peter Chandra"
 
@@ -17,33 +17,33 @@ RUN apt-get update \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E5267A6C \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \
-    && echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu focal main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
+    && echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && curl -sL https://deb.nodesource.com/setup_lts.x | bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
-    && apt-get install -y php8.0-cli php8.0-dev \
-       php8.0-apcu \
-       php8.0-bcmath \
-       php8.0-curl \
-       php8.0-imap \
-       php8.0-gd \
-       php8.0-igbinary \
-       php8.0-imagick \
-       php8.0-intl \
-       php8.0-ldap \
-       php8.0-mbstring \
-       php8.0-msgpack \
-       php8.0-mysql \
-       php8.0-pgsql \
-       php8.0-readline \
-       php8.0-redis \
-       php8.0-sqlite3 \
-       php8.0-soap \
-       php8.0-xdebug \
-       php8.0-xml \
-       php8.0-yaml \
-       php8.0-zip \
+    && apt-get install -y php8.3-cli php8.3-dev \
+       php8.3-apcu \
+       php8.3-bcmath \
+       php8.3-curl \
+       php8.3-imap \
+       php8.3-gd \
+       php8.3-igbinary \
+       php8.3-imagick \
+       php8.3-intl \
+       php8.3-ldap \
+       php8.3-mbstring \
+       php8.3-msgpack \
+       php8.3-mysql \
+       php8.3-pgsql \
+       php8.3-readline \
+       php8.3-redis \
+       php8.3-sqlite3 \
+       php8.3-soap \
+       php8.3-xdebug \
+       php8.3-xml \
+       php8.3-yaml \
+       php8.3-zip \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && apt-get install -y mysql-client \
     && apt-get install -y nodejs \
@@ -52,14 +52,14 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
+RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.3
 
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
+COPY php.ini /etc/php/8.3/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 8000

--- a/veriscope_ta_dashboard/package.json
+++ b/veriscope_ta_dashboard/package.json
@@ -13,7 +13,7 @@
         "test-js": "cross-env NODE_ENV=testing mocha-webpack --webpack-config=node_modules/laravel-mix/setup/webpack.config.js --require tests/Vue/setup.js tests/Vue/**/*.spec.js"
     },
     "devDependencies": {
-        "axios": "^0.21.4",
+        "axios": "^1.6.0",
         "cross-env": "^5.2.1",
         "expect": "^27.2.1",
         "jquery": "^3.6",

--- a/veriscope_ta_node/package.json
+++ b/veriscope_ta_node/package.json
@@ -5,7 +5,7 @@
     "@0xhamachi/ethereum-events": "^0.1.1",
     "@ethereumjs/devp2p": "^4.2.0",
     "@keyv/redis": "^2.2.1",
-    "axios": "^0.21.4",
+    "axios": "^1.6.0",
     "bull": "^4.1.1",
     "bull-arena": "^2.6.2",
     "cookie-parser": "^1.4.6",


### PR DESCRIPTION
- Upgrade Ubuntu 20.04 to 22.04 in all Dockerfiles
- Upgrade PHP 8.0 to 8.3 across all configuration files
- Upgrade Python 3.8 to 3.11 in Lambda Dockerfile
- Upgrade axios from 0.21.4 to 1.6.0 in package.json files

These updates address end-of-life versions and known security vulnerabilities.